### PR TITLE
Update ngClick.js

### DIFF
--- a/src/ngTouch/directive/ngClick.js
+++ b/src/ngTouch/directive/ngClick.js
@@ -142,7 +142,7 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
       lastLabelClickCoordinates = null;
     }
     // remember label click coordinates to prevent click busting of trigger click event on input
-    if (event.target.tagName.toLowerCase() === 'label') {
+    if (event.target.tagName.toLowerCase() === 'label' || findUpLabel(event.target)) {
       lastLabelClickCoordinates = [x, y];
     }
 
@@ -161,6 +161,14 @@ ngTouch.directive('ngClick', ['$parse', '$timeout', '$rootElement',
     event.target && event.target.blur();
   }
 
+    function findUpLabel(el) {
+		while (el.parentNode) {
+			el = el.parentNode;
+			if (el.tagName && el.tagName.toLowerCase() === 'label')
+				return el;
+		}
+		return null;
+	}
 
   // Global touchstart handler that creates an allowable region for a click event.
   // This allowable region can be removed by preventGhostClick if we want to bust it.


### PR DESCRIPTION
In our code we have an input element inside a label. The click on the label generates two clicks, but the second click was not recognised by angular-touch as a label click, because it only looks at the current element, instead of looking  for a label in parent elements. Therefore, the second click gets busted, and clicking on the label doesn't do anything for 2500ms.
 
I added the additional lookup for a containing label inside one of the conditions inside the onClick method.